### PR TITLE
Refactor style usage across components

### DIFF
--- a/app/admin/duzenle.js
+++ b/app/admin/duzenle.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, TextInput, ScrollView, TouchableOpacity, Alert } from "react-native";
+import { View, Text, TextInput, ScrollView, TouchableOpacity, Alert, StyleSheet } from "react-native";
 import axiosClient from '../../src/api/axiosClient';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useLocalSearchParams, useRouter, useNavigation } from "expo-router";
@@ -82,20 +82,20 @@ const handleDelete = () => {
 };
 
   return (
-    <ScrollView contentContainerStyle={{ padding: 16 }}>
-      <Text style={{ fontSize: 24, fontWeight: "bold", marginBottom: 16 }}>Etkinliği Düzenle</Text>
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Etkinliği Düzenle</Text>
 
       <Text>Başlık</Text>
-      <TextInput value={form.baslik} onChangeText={text => handleChange("baslik", text)} style={{ borderWidth: 1, padding: 8, marginBottom: 12 }} />
+      <TextInput value={form.baslik} onChangeText={text => handleChange("baslik", text)} style={styles.input} />
 
       <Text>Şehir</Text>
-      <TextInput value={form.sehir} onChangeText={text => handleChange("sehir", text)} style={{ borderWidth: 1, padding: 8, marginBottom: 12 }} />
+      <TextInput value={form.sehir} onChangeText={text => handleChange("sehir", text)} style={styles.input} />
 
       <Text>Tarih</Text>
-      <TextInput value={form.tarih} onChangeText={text => handleChange("tarih", text)} style={{ borderWidth: 1, padding: 8, marginBottom: 12 }} placeholder="yyyy-mm-dd" />
+      <TextInput value={form.tarih} onChangeText={text => handleChange("tarih", text)} style={styles.input} placeholder="yyyy-mm-dd" />
 
       <Text>Fiyat</Text>
-      <TextInput value={form.fiyat} onChangeText={text => handleChange("fiyat", text)} style={{ borderWidth: 1, padding: 8, marginBottom: 12 }} />
+      <TextInput value={form.fiyat} onChangeText={text => handleChange("fiyat", text)} style={styles.input} />
 
       <Text>Kategori</Text>
       <Picker selectedValue={form.kategori} onValueChange={(val) => handleChange("kategori", val)}>
@@ -114,25 +114,41 @@ const handleDelete = () => {
       </Picker>
 
       <Text>Görsel URL</Text>
-      <TextInput value={form.gorsel} onChangeText={text => handleChange("gorsel", text)} style={{ borderWidth: 1, padding: 8, marginBottom: 12 }} />
+      <TextInput value={form.gorsel} onChangeText={text => handleChange("gorsel", text)} style={styles.input} />
       {form.gorsel?.length > 5 && (
       <FastImage
         uri={form.gorsel}
         cacheKey={form.gorsel}
-        style={{ width: '100%', height: 220, borderRadius: 12, marginBottom: 12 }}
+        style={styles.preview}
       />
     )}
 
       <Text>Açıklama</Text>
-      <TextInput multiline numberOfLines={4} value={form.aciklama} onChangeText={text => handleChange("aciklama", text)} style={{ borderWidth: 1, padding: 8, marginBottom: 12 }} />
+      <TextInput multiline numberOfLines={4} value={form.aciklama} onChangeText={text => handleChange("aciklama", text)} style={styles.input} />
 
-      <TouchableOpacity onPress={handleSubmit} style={{ backgroundColor: '#6c5ce7', padding: 12, borderRadius: 8, marginBottom: 10 }}>
-        <Text style={{ color: '#fff', textAlign: 'center', fontWeight: 'bold' }}>Güncelle</Text>
+      <TouchableOpacity onPress={handleSubmit} style={styles.updateButton}>
+        <Text style={styles.updateButtonText}>Güncelle</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity onPress={handleDelete} style={{ backgroundColor: '#d63031', padding: 12, borderRadius: 8 }}>
-        <Text style={{ color: '#fff', textAlign: 'center', fontWeight: 'bold' }}>Etkinliği Sil</Text>
+      <TouchableOpacity onPress={handleDelete} style={styles.deleteButton}>
+        <Text style={styles.deleteButtonText}>Etkinliği Sil</Text>
       </TouchableOpacity>
     </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 16 },
+  input: { borderWidth: 1, padding: 8, marginBottom: 12 },
+  preview: { width: '100%', height: 220, borderRadius: 12, marginBottom: 12 },
+  updateButton: {
+    backgroundColor: '#6c5ce7',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  updateButtonText: { color: '#fff', textAlign: 'center', fontWeight: 'bold' },
+  deleteButton: { backgroundColor: '#d63031', padding: 12, borderRadius: 8 },
+  deleteButtonText: { color: '#fff', textAlign: 'center', fontWeight: 'bold' },
+});

--- a/app/arama-sonuclari.js
+++ b/app/arama-sonuclari.js
@@ -1,6 +1,6 @@
 // app/arama-sonuclari.js
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, Image, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import axiosClient from "../src/api/axiosClient";
 import { useCallback } from 'react';
@@ -42,47 +42,39 @@ useEffect(() => {
 
 const renderItem = useCallback(({ item }) => (
   <TouchableOpacity
-    onPress={() => router.push({ pathname: '/etkinlik/[id]', params: { id: item.id } })}
-    style={{
-      backgroundColor: '#fff',
-      padding: 14,
-      marginBottom: 16,
-      borderRadius: 12,
-      shadowColor: '#000',
-      shadowOpacity: 0.05,
-      shadowRadius: 8,
-      shadowOffset: { width: 0, height: 4 },
-      elevation: 3,
-    }}
+    onPress={() =>
+      router.push({ pathname: '/etkinlik/[id]', params: { id: item.id } })
+    }
+    style={styles.card}
   >
   <Image
     source={{ uri: `https://rotabackend-f4gqewcbfcfud4ac.qatarcentral-01.azurewebsites.net${item.gorsel}` }}
 
-      style={{ width: '100%', height: 270, borderRadius: 6 }}
+      style={styles.image}
       resizeMode="cover"
     />
-    <Text style={{ fontSize: 18, fontWeight: '700', color: '#333', marginTop: 8 }}>
+    <Text style={styles.title}>
       {item.baslik}
     </Text>
-    <Text style={{ fontSize: 14, color: '#666', marginTop: 2 }}>
+    <Text style={styles.meta}>
       {item.sehir} • {item.tarih}
     </Text>
-    <Text style={{ marginTop: 4, color: '#333', fontWeight: '500' }}>
+    <Text style={styles.info}>
       {(item.fiyat && item.fiyat !== '0') ? `${item.fiyat} ₺` : 'Ücretsiz'} • {item.kategori}
     </Text>
   </TouchableOpacity>
 ), []);
 
   return (
-    <View style={{ padding: 16, backgroundColor: '#f2f2f2', flex: 1 }}>
-        <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 12 }}>
+    <View style={styles.container}>
+        <Text style={styles.header}>
         {q || sehir} için sonuçlar
         </Text>
 
       {loading ? (
         <ActivityIndicator size="large" color="#6c5ce7" />
       ) : etkinlikler.length === 0 ? (
-        <Text style={{ color: '#888' }}>Etkinlik bulunamadı.</Text>
+        <Text style={styles.empty}>Etkinlik bulunamadı.</Text>
       ) : (
       <FlatList
         data={etkinlikler}
@@ -97,4 +89,52 @@ const renderItem = useCallback(({ item }) => (
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    backgroundColor: '#f2f2f2',
+    flex: 1,
+  },
+  header: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  card: {
+    backgroundColor: '#fff',
+    padding: 14,
+    marginBottom: 16,
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 3,
+  },
+  image: {
+    width: '100%',
+    height: 270,
+    borderRadius: 6,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#333',
+    marginTop: 8,
+  },
+  meta: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 2,
+  },
+  info: {
+    marginTop: 4,
+    color: '#333',
+    fontWeight: '500',
+  },
+  empty: {
+    color: '#888',
+  },
+});
 

--- a/app/etkinlik-ekle.js
+++ b/app/etkinlik-ekle.js
@@ -141,13 +141,7 @@ const handleSubmit = async () => {
 <Picker
   selectedValue={sehir}
   onValueChange={(val) => setSehir(val)}
-  style={{
-    backgroundColor: '#fff',
-    borderRadius: 8,
-    borderColor: '#ccc',
-    borderWidth: 1,
-    marginBottom: 16,
-  }}
+  style={styles.cityPicker}
 >
   {[  "Adana", "Adıyaman", "Afyonkarahisar", "Ağrı", "Amasya", "Ankara", "Antalya", "Artvin", "Aydın",
   "Balıkesir", "Bilecik", "Bingöl", "Bitlis", "Bolu", "Burdur", "Bursa", "Çanakkale", "Çankırı",
@@ -291,6 +285,13 @@ picker: {
   borderColor: '#ddd',
   borderWidth: 1,
   paddingHorizontal: 6,
+  marginBottom: 16,
+},
+cityPicker: {
+  backgroundColor: '#fff',
+  borderRadius: 8,
+  borderColor: '#ccc',
+  borderWidth: 1,
   marginBottom: 16,
 },
 imageButton: {

--- a/app/etkinlik/[id].js
+++ b/app/etkinlik/[id].js
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import axios from 'axios';
 import { useLocalSearchParams } from 'expo-router';
 import React, { useEffect, useState, useRef } from 'react';
-import { Alert, Image, ScrollView, Text, TextInput, TouchableOpacity, View, Platform } from 'react-native';
+import { Alert, Image, ScrollView, Text, TextInput, TouchableOpacity, View, Platform, StyleSheet } from 'react-native';
 import { useContext } from 'react';
 import { AuthContext } from '../../src/context/AuthContext';
 import { router } from 'expo-router';
@@ -261,7 +261,7 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
   return (
 <KeyboardAvoidingView
   behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-  style={{ flex: 1 }}
+  style={styles.flex}
   keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
 >
 <ScrollView
@@ -269,29 +269,15 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
   keyboardShouldPersistTaps="handled"
   keyboardDismissMode="interactive"
   contentInsetAdjustmentBehavior="automatic"
-  contentContainerStyle={{
-    padding: 16,
-    paddingBottom: 200,
-    backgroundColor: '#f2f2f2' // AÇIK GRİ ARKA PLAN
-  }}
+  contentContainerStyle={styles.scrollContent}
 >
         <FastImage
           uri={gorselSrc}
           cacheKey={etkinlik.id}
-          style={{
-            width: '100%',
-            height: 330,
-            borderRadius: 16,
-            marginTop: 12,
-            shadowColor: '#000',
-            shadowOpacity: 0.1,
-            shadowRadius: 8,
-            shadowOffset: { width: 0, height: 4 },
-            elevation: 3,
-          }}
+          style={styles.headerImage}
         />
 
-        <View style={{ marginTop: 20, backgroundColor: '#fff', borderRadius: 12, padding: 16 }}>
+        <View style={styles.sectionFirst}>
           <Text style={{ fontSize: 22, fontWeight: '700', color: TEXT, marginBottom: 4 }}>
             {etkinlik.baslik}
           </Text>
@@ -305,16 +291,12 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
 
           <TouchableOpacity
             onPress={favoriToggle}
-            style={{
-              marginTop: 20,
-              paddingVertical: 12,
-              borderRadius: 8,
-              backgroundColor: favorideMi ? '#f8f4ff' : '#fff',
-              borderWidth: 1,
-              borderColor: PRIMARY,
-            }}
+            style={[
+              styles.favButton,
+              { backgroundColor: favorideMi ? '#f8f4ff' : '#fff' },
+            ]}
           >
-            <Text style={{ textAlign: 'center', color: PRIMARY, fontWeight: '600' }}>
+            <Text style={styles.favButtonText}>
               {favorideMi ? 'Favoriden Çıkar' : 'Favorilere Ekle'}
             </Text>
           </TouchableOpacity>
@@ -329,50 +311,25 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
                     params: { ...etkinlik, token },
                   });
                 }}
-                style={{
-                  backgroundColor: '#00cec9',
-                  paddingVertical: 14,
-                  borderRadius: 10,
-                  shadowColor: '#000',
-                  shadowOpacity: 0.08,
-                  shadowOffset: { width: 0, height: 2 },
-                  shadowRadius: 4,
-                  elevation: 2,
-                }}
+                style={[styles.adminButton, { backgroundColor: '#00cec9' }]}
               >
-                <Text style={{ color: '#fff', fontSize: 15, fontWeight: '600', textAlign: 'center' }}>
+                <Text style={styles.adminButtonText}>
                   ✏️ Etkinliği Düzenle
                 </Text>
               </TouchableOpacity>
 
               <TouchableOpacity
                 onPress={etkinlikSil}
-                style={{
-                  backgroundColor: '#d63031',
-                  paddingVertical: 14,
-                  borderRadius: 10,
-                  shadowColor: '#000',
-                  shadowOpacity: 0.08,
-                  shadowOffset: { width: 0, height: 2 },
-                  shadowRadius: 4,
-                  elevation: 2,
-                }}
+                style={[styles.adminButton, { backgroundColor: '#d63031' }]}
               >
-                <Text style={{ color: '#fff', fontSize: 15, fontWeight: '600', textAlign: 'center' }}>
+                <Text style={styles.adminButtonText}>
                   🗑️ Etkinliği Sil
                 </Text>
               </TouchableOpacity>
             </View>
           )}
-          <View
-            style={{
-              marginTop: 16,
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              justifyContent: 'center',
-              gap: 18,
-            }}
-          >
+          <View style={styles.shareRow}
+           >
             {[
               { tip: 'instagram', icon: '📸' },
               { tip: 'facebook', icon: '📘' },
@@ -384,14 +341,7 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
               <TouchableOpacity
                 key={tip}
                 onPress={() => paylaş(tip)}
-                style={{
-                  width: 36,
-                  height: 36,
-                  borderRadius: 12,
-                  backgroundColor: '#f0f0f0',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                }}
+                style={styles.shareButton}
               >
                 <Text style={{ fontSize: 22 }}>{icon}</Text>
               </TouchableOpacity>
@@ -467,34 +417,21 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
           )}
 
           {auth?.token ? (
-            <View style={{ marginTop: 16, paddingBottom: 40 }}>
+            <View style={styles.commentBox}>
               <TextInput
                 placeholder="Yorumunuzu yazın..."
                 value={yeniYorum}
                 onChangeText={setYeniYorum}
               multiline
               scrollEnabled={false}
-                style={{
-                  borderColor: '#ccc',
-                  borderWidth: 1,
-                  borderRadius: 8,
-                  padding: 12,
-                  marginBottom: 12,
-                  minHeight: 70,
-                }}
+              style={styles.commentInput}
               
               />
               <TouchableOpacity
                 onPress={yorumGonder}
-                style={{
-                  backgroundColor: PRIMARY,
-                  borderRadius: 8,
-                  paddingVertical: 12,
-                  alignSelf: 'flex-end',
-                  width: 120,
-                }}
+                style={styles.commentButton}
               >
-                <Text style={{ color: '#fff', textAlign: 'center', fontWeight: '600', fontSize: 16 }}>
+                <Text style={styles.commentButtonText}>
                   Gönder
                 </Text>
               </TouchableOpacity>
@@ -527,8 +464,8 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
                   );
                 })}
               </ScrollView>
-              <TouchableOpacity onPress={() => setModalVisible(false)} style={{ marginTop: 12, backgroundColor: PRIMARY, borderRadius: 8, paddingVertical: 10 }}>
-                <Text style={{ color: '#fff', textAlign: 'center', fontWeight: '600' }}>Kapat</Text>
+        <TouchableOpacity onPress={() => setModalVisible(false)} style={styles.modalClose}>
+                <Text style={styles.modalCloseText}>Kapat</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -537,3 +474,104 @@ const gorselSrc = etkinlik.gorsel?.startsWith('http') ? etkinlik.gorsel : `${bac
 </KeyboardAvoidingView>
   );
 }
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 200,
+    backgroundColor: '#f2f2f2',
+  },
+  headerImage: {
+    width: '100%',
+    height: 330,
+    borderRadius: 16,
+    marginTop: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 3,
+  },
+  sectionFirst: {
+    marginTop: 20,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+  },
+  favButton: {
+    marginTop: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: PRIMARY,
+  },
+  favButtonText: {
+    textAlign: 'center',
+    color: PRIMARY,
+    fontWeight: '600',
+  },
+  adminButton: {
+    paddingVertical: 14,
+    borderRadius: 10,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  adminButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  shareRow: {
+    marginTop: 16,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 18,
+  },
+  shareButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 12,
+    backgroundColor: '#f0f0f0',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  commentBox: { marginTop: 16, paddingBottom: 40 },
+  commentInput: {
+    borderColor: '#ccc',
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+    minHeight: 70,
+  },
+  commentButton: {
+    backgroundColor: PRIMARY,
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignSelf: 'flex-end',
+    width: 120,
+  },
+  commentButtonText: {
+    color: '#fff',
+    textAlign: 'center',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  modalClose: {
+    marginTop: 12,
+    backgroundColor: PRIMARY,
+    borderRadius: 8,
+    paddingVertical: 10,
+  },
+  modalCloseText: {
+    color: '#fff',
+    textAlign: 'center',
+    fontWeight: '600',
+  },
+});

--- a/app/login.jsx
+++ b/app/login.jsx
@@ -82,7 +82,7 @@ setToken(accessToken);
         keyboardType="email-address"
         autoCapitalize="none"
       />
-<View style={{ position: 'relative' }}>
+<View style={styles.relative}>
   <TextInput
     style={styles.input}
     placeholder="Şifre"
@@ -168,6 +168,9 @@ link: {
   textAlign: 'center',
   marginTop: 16,
   fontSize: 13,
+},
+relative: {
+  position: 'relative',
 }
 });
 

--- a/app/register.jsx
+++ b/app/register.jsx
@@ -63,7 +63,7 @@ const RegisterScreen = () => {
           autoCapitalize="none"
         />
 
-        <View style={{ position: 'relative' }}>
+        <View style={styles.relative}>
           <TextInput
             style={styles.input}
             placeholder="Şifre"
@@ -79,7 +79,7 @@ const RegisterScreen = () => {
           </TouchableOpacity>
         </View>
 
-        <View style={{ position: 'relative' }}>
+        <View style={styles.relative}>
           <TextInput
             style={styles.input}
             placeholder="Şifre (tekrar)"
@@ -161,6 +161,9 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginTop: 20,
     fontSize: 13,
+  },
+  relative: {
+    position: 'relative',
   }
 });
 

--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -1,4 +1,4 @@
-import { View, TouchableOpacity, Text } from 'react-native';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { useRouter, usePathname } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Platform } from 'react-native';
@@ -15,22 +15,47 @@ const BottomTabBar = () => {
   ];
 
   return (
-      <View style={{
-        flexDirection: 'row',
-        justifyContent: 'space-around',
-        padding: 12,
-        borderTopWidth: 1,
-        borderTopColor: '#ccc',
-        backgroundColor: '#fff'
-      }}>
+    <View style={styles.container}>
       {tabs.map((tab, index) => (
-        <TouchableOpacity key={index} onPress={() => router.push(tab.path)} style={{ alignItems: 'center' }}>
-          <Ionicons name={tab.icon} size={24} color={pathname === tab.path ? '#6c5ce7' : 'gray'} />
-          <Text style={{ fontSize: 10, color: pathname === tab.path ? '#6c5ce7' : 'gray' }}>{tab.name}</Text>
+        <TouchableOpacity
+          key={index}
+          onPress={() => router.push(tab.path)}
+          style={styles.tab}
+        >
+          <Ionicons
+            name={tab.icon}
+            size={24}
+            color={pathname === tab.path ? '#6c5ce7' : 'gray'}
+          />
+          <Text
+            style={[
+              styles.tabText,
+              { color: pathname === tab.path ? '#6c5ce7' : 'gray' },
+            ]}
+          >
+            {tab.name}
+          </Text>
         </TouchableOpacity>
       ))}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    padding: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#ccc',
+    backgroundColor: '#fff',
+  },
+  tab: {
+    alignItems: 'center',
+  },
+  tabText: {
+    fontSize: 10,
+  },
+});
 
 export default BottomTabBar;

--- a/src/components/CommentCard.js
+++ b/src/components/CommentCard.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useContext } from 'react';
-import { Alert, Image, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Alert, Image, Text, TextInput, TouchableOpacity, View, StyleSheet } from 'react-native';
 import axiosClient from '../api/axiosClient';
 import { AuthContext } from '../context/AuthContext';
 
@@ -19,12 +19,12 @@ const zamanFarki = (tarih) => {
 };
 
 const touchableIcon = (liked, onPress, count, tarih) => (
-  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+  <View style={styles.iconRow}>
     <TouchableOpacity onPress={onPress}>
-      <Text style={{ fontSize: 18 }}>{liked ? '💜' : '🤍'}</Text>
+      <Text style={styles.icon}>{liked ? '💜' : '🤍'}</Text>
     </TouchableOpacity>
-    <Text style={{ fontSize: 12, color: '#888' }}>{count}</Text>
-    <Text style={{ fontSize: 12, color: '#aaa' }}>· {zamanFarki(tarih)}</Text>
+    <Text style={styles.iconCount}>{count}</Text>
+    <Text style={styles.iconTime}>· {zamanFarki(tarih)}</Text>
   </View>
 );
 
@@ -90,29 +90,29 @@ function CommentCard({
   };
 
   return (
-    <View key={yorum._id} style={{ marginBottom: 12 }}>
-      <View style={{ flexDirection: 'row', paddingLeft: isAltYorum ? 48 : 0 }}>
-        <Image source={{ uri: yorum.avatarUrl }} style={{ width: 40, height: 40, borderRadius: 20, marginRight: 10 }} />
-        <View style={{ flex: 1 }}>
-          <Text style={{ fontWeight: '600' }}>{yorum.kullanici}</Text>
+    <View key={yorum._id} style={styles.card}>
+      <View style={[styles.row, { paddingLeft: isAltYorum ? 48 : 0 }]}>
+        <Image source={{ uri: yorum.avatarUrl }} style={styles.avatar} />
+        <View style={styles.flex1}>
+          <Text style={styles.name}>{yorum.kullanici}</Text>
 
           {duzenleModu ? (
             <>
               <TextInput
                 value={duzenlenenMetin}
                 onChangeText={setDuzenlenenMetin}
-                style={{ borderWidth: 1, borderColor: '#ccc', borderRadius: 6, padding: 8, marginVertical: 4 }}
+                style={styles.editInput}
                 multiline
               />
-              <TouchableOpacity onPress={yorumuGuncelle} style={{ backgroundColor: PRIMARY, padding: 6, borderRadius: 6 }}>
-                <Text style={{ color: '#fff' }}>Kaydet</Text>
+              <TouchableOpacity onPress={yorumuGuncelle} style={styles.saveButton}>
+                <Text style={styles.saveButtonText}>Kaydet</Text>
               </TouchableOpacity>
             </>
           ) : (
-            <Text style={{ color: '#555', marginVertical: 4 }}>{yorum.yorum}</Text>
+            <Text style={styles.commentText}>{yorum.yorum}</Text>
           )}
 
-          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <View style={styles.actionRow}>
             {touchableIcon(
               yorum.begendinMi,
               async () => {
@@ -125,13 +125,17 @@ function CommentCard({
               yorum.tarih
             )}
 
-            <View style={{ flexDirection: 'row', gap: 8 }}>
+            <View style={styles.replyRow}>
               <TouchableOpacity onPress={() => setYanitId(yorum._id)}>
                 <Text style={{ color: PRIMARY }}>Yanıtla</Text>
               </TouchableOpacity>
             </View>
           </View>
-          <View style={{ marginTop: 8, display: String(yanitId) === String(yorum._id) ? 'flex' : 'none' }}>
+          <View style={[
+              styles.replyContainer,
+              { display: String(yanitId) === String(yorum._id) ? 'flex' : 'none' },
+            ]}
+          >
             <TextInput
               ref={inputRef}
               value={yanitlar[yorum._id] || ''}
@@ -144,26 +148,13 @@ function CommentCard({
               multiline
               scrollEnabled
               blurOnSubmit={false}
-              style={{
-                borderWidth: 1,
-                borderColor: '#ccc',
-                borderRadius: 8,
-                padding: 10,
-                minHeight: 60,
-              }}
+              style={styles.replyInput}
             />
             <TouchableOpacity
               onPress={() => yanitGonder(yorum._id)}
-              style={{
-                backgroundColor: PRIMARY,
-                borderRadius: 8,
-                paddingVertical: 10,
-                marginTop: 10,
-                alignSelf: 'flex-end',
-                width: 100,
-              }}
+              style={styles.replyButton}
             >
-              <Text style={{ color: '#fff', textAlign: 'center', fontWeight: '600' }}>Yanıtla</Text>
+              <Text style={styles.replyButtonText}>Yanıtla</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -187,3 +178,52 @@ function CommentCard({
 }
 
 export default React.memo(CommentCard);
+
+const styles = StyleSheet.create({
+  card: { marginBottom: 12 },
+  row: { flexDirection: 'row' },
+  avatar: { width: 40, height: 40, borderRadius: 20, marginRight: 10 },
+  flex1: { flex: 1 },
+  name: { fontWeight: '600' },
+  editInput: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 6,
+    padding: 8,
+    marginVertical: 4,
+  },
+  saveButton: { backgroundColor: PRIMARY, padding: 6, borderRadius: 6 },
+  saveButtonText: { color: '#fff' },
+  commentText: { color: '#555', marginVertical: 4 },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  replyRow: { flexDirection: 'row', gap: 8 },
+  replyContainer: { marginTop: 8 },
+  replyInput: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 10,
+    minHeight: 60,
+  },
+  replyButton: {
+    backgroundColor: PRIMARY,
+    borderRadius: 8,
+    paddingVertical: 10,
+    marginTop: 10,
+    alignSelf: 'flex-end',
+    width: 100,
+  },
+  replyButtonText: {
+    color: '#fff',
+    textAlign: 'center',
+    fontWeight: '600',
+  },
+  iconRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  icon: { fontSize: 18 },
+  iconCount: { fontSize: 12, color: '#888' },
+  iconTime: { fontSize: 12, color: '#aaa' },
+});

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -214,13 +214,13 @@ if (bildirim.tip === 'favori' && bildirim.etkinlikId) {
 )}
 
 {isLoggedIn && (
-  <View style={{ position: 'relative' }}>
+  <View style={styles.relative}>
     <TouchableOpacity onPress={() => setIsProfileDropdownOpen(!isProfileDropdownOpen)}>
       <View style={styles.avatar}>
         {profilePhoto ? (
           <Image
             source={{ uri: profilePhoto }}
-            style={{ width: 32, height: 32, borderRadius: 16 }}
+            style={styles.profileImage}
             resizeMode="cover"
           />
         ) : (
@@ -353,12 +353,12 @@ if (bildirim.tip === 'favori' && bildirim.etkinlikId) {
     {bildirimler.length === 0 ? (
       <Text style={styles.panelEmpty}>Henüz bildirimin yok.</Text>
     ) : (
-<View style={{ maxHeight: 220 }}>
+<View style={styles.maxHeightList}>
   <FlatList
     data={bildirimler.slice(0, 12)} 
     keyExtractor={(item, index) => index.toString()}
     showsVerticalScrollIndicator={true}
-    style={{ maxHeight: 220 }}
+    style={styles.maxHeightList}
     contentContainerStyle={{ paddingBottom: 20 }}
     renderItem={({ item, index }) => {
         const etkinlik = item.etkinlikId || item.etkinlik || {};
@@ -679,6 +679,17 @@ panelEventText: {
   fontSize: 13,
   color: '#444',
 }
+relative: {
+  position: "relative",
+},
+profileImage: {
+  width: 32,
+  height: 32,
+  borderRadius: 16,
+},
+maxHeightList: {
+  maxHeight: 220,
+},
 
   });
   export default Header;

--- a/src/components/SafeFlatList.js
+++ b/src/components/SafeFlatList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlatList, Text } from 'react-native';
+import { FlatList, Text, StyleSheet } from 'react-native';
 import logger from '../utils/logger';
 
 const SafeFlatList = ({ data, renderItem, keyExtractor, ...props }) => {
@@ -10,7 +10,7 @@ const SafeFlatList = ({ data, renderItem, keyExtractor, ...props }) => {
     } catch (e) {
       logger.warn('renderItem error at index', index, e);
 
-      return <Text style={{ color: 'red', padding: 10 }}>Hatalı içerik: {index}</Text>;
+      return <Text style={styles.error}>Hatalı içerik: {index}</Text>;
     }
   };
 
@@ -34,3 +34,10 @@ const SafeFlatList = ({ data, renderItem, keyExtractor, ...props }) => {
 };
 
 export default SafeFlatList;
+
+const styles = StyleSheet.create({
+  error: {
+    color: 'red',
+    padding: 10,
+  },
+});

--- a/src/components/admin/EtkinlikOnay.js
+++ b/src/components/admin/EtkinlikOnay.js
@@ -74,9 +74,8 @@ const EtkinlikOnay = () => {
             <View key={etkinlik.id || etkinlik._id} style={styles.card}>
             <Image
               source={{ uri: `https://rotabackend-f4gqewcbfcfud4ac.qatarcentral-01.azurewebsites.net/img/${etkinlik.gorsel?.split('/').pop()}` }}
-              style={{ width: 200, height: 200 }}
+              style={styles.image}
               onError={() => logger.log('Görsel yüklenemedi')}
-
             />
             <Text style={styles.title}>{etkinlik.baslik}</Text>
             <Text style={styles.text}>{etkinlik.sehir} - {etkinlik.tarih}</Text>
@@ -107,8 +106,8 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   image: {
-    width: '100%',
-    height: 160,
+    width: 200,
+    height: 200,
     borderRadius: 8,
   },
   title: {

--- a/src/components/admin/Kullanicilar.js
+++ b/src/components/admin/Kullanicilar.js
@@ -72,7 +72,7 @@ const Kullanicilar = () => {
     }
   };
 
-  if (loading) return <ActivityIndicator size="large" color="#007bff" style={{ marginTop: 50 }} />;
+  if (loading) return <ActivityIndicator size="large" color="#007bff" style={styles.loading} />;
 
   return (
 <View style={styles.container}>
@@ -113,6 +113,9 @@ const Kullanicilar = () => {
 const styles = StyleSheet.create({
   container: {
     padding: 16,
+  },
+  loading: {
+    marginTop: 50,
   },
   header: {
     fontSize: 22,


### PR DESCRIPTION
## Summary
- centralize BottomTabBar inline styles
- move error text style in SafeFlatList
- organize CommentCard styles
- tweak Header for reusable styles
- extract styles in admin components
- refactor multiple pages to use StyleSheet

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a11ce448833386203e703c6a3565